### PR TITLE
calculate totalVolumeETH and totalVolumeUSD

### DIFF
--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -132,8 +132,16 @@ export function handleRiseTokenMinted(event: RiseTokenMinted): void {
 	riseTokenUpdate(event.params.riseToken.toHex(), event.transaction.value);
 
 	// price update
-	hourlyVolumeUpdate(event, event.transaction.value);
-	dailyVolumeUpdate(event, event.transaction.value);
+	hourlyVolumeUpdate(
+		event,
+		event.params.riseToken.toHex(),
+		event.transaction.value
+	);
+	dailyVolumeUpdate(
+		event,
+		event.params.riseToken.toHex(),
+		event.transaction.value
+	);
 }
 
 export function handleRiseTokenBurned(event: RiseTokenBurned): void {
@@ -216,8 +224,16 @@ export function handleRiseTokenBurned(event: RiseTokenBurned): void {
 	);
 
 	// price update
-	hourlyVolumeUpdate(event, event.params.redeemedAmount);
-	dailyVolumeUpdate(event, event.params.redeemedAmount);
+	hourlyVolumeUpdate(
+		event,
+		event.params.riseToken.toHex(),
+		event.params.redeemedAmount
+	);
+	dailyVolumeUpdate(
+		event,
+		event.params.riseToken.toHex(),
+		event.params.redeemedAmount
+	);
 }
 
 export function handleRiseTokenRebalanced(event: RiseTokenRebalanced): void {

--- a/src/mappings/updates.ts
+++ b/src/mappings/updates.ts
@@ -36,6 +36,7 @@ export function riseTokenUpdate(
 
 export function hourlyVolumeUpdate(
 	event: ethereum.Event,
+	riseTokenAddress: string,
 	amount: BigInt
 ): void {
 	// hourly update
@@ -66,10 +67,20 @@ export function hourlyVolumeUpdate(
 		convertUSDCToDecimal(oracleContract.getPrice())
 	);
 	riseTokenHourData.txCount = riseTokenHourData.txCount.plus(ONE_BI);
-	riseTokenHourData.save();
+
+	let riseToken = RiseToken.load(riseTokenAddress);
+	if (riseToken) {
+		riseTokenHourData.totalVolumeETH = riseToken.tradeVolume;
+		riseTokenHourData.totalVolumeUSD = riseToken.tradeVolumeUSD;
+		riseTokenHourData.save();
+	}
 }
 
-export function dailyVolumeUpdate(event: ethereum.Event, amount: BigInt): void {
+export function dailyVolumeUpdate(
+	event: ethereum.Event,
+	riseTokenAddress: string,
+	amount: BigInt
+): void {
 	// daily update
 	const dayTimestamp = event.block.timestamp.div(BigInt.fromI32(86400));
 	let riseTokenDayData = RiseTokenDayData.load(dayTimestamp.toString());
@@ -96,5 +107,11 @@ export function dailyVolumeUpdate(event: ethereum.Event, amount: BigInt): void {
 		convertUSDCToDecimal(oracleContract.getPrice())
 	);
 	riseTokenDayData.txCount = riseTokenDayData.txCount.plus(ONE_BI);
-	riseTokenDayData.save();
+	
+	let riseToken = RiseToken.load(riseTokenAddress);
+	if (riseToken) {
+		riseTokenDayData.totalVolumeETH = riseToken.tradeVolume;
+		riseTokenDayData.totalVolumeUSD = riseToken.tradeVolumeUSD;
+		riseTokenDayData.save();
+	}
 }


### PR DESCRIPTION
## How

Let's say we talk about totalVolumeETH on RiseTokenDayData. We want to know what's the total mint amount + redeem amounts in ETH. So first of all, we have to know how to get those amounts. 

When we want to know the amounts of mint value, we should look to RiseTokenMinted events located in handleRiseTokenMinted. When we want to know the amounts of redeem value, we should look to RiseTokenBurned events located in handleRiseTokenBurned.

And also we want to know the totalVolumeETH before a timestamp. So we need to store that value to an entity — RiseToken.