### PR TITLE
✦ RIS-429: DAU MAU fix

### DIFF
--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -10,10 +10,8 @@ import {
 } from "../types/RiseTokenVault/RiseTokenVault";
 import {
 	Burn,
-	DailyActiveUser,
 	Deposit,
 	Mint,
-	MonthlyActiveUser,
 	Rebalance,
 	RiseToken,
 	Transaction,
@@ -28,15 +26,16 @@ import {
 	fetchTokenName,
 	fetchTokenSymbol,
 	fetchTokenTotalSupply,
-	ONE_BI,
 	oracleContract,
 	tokenAddress,
 	vaultContract,
 	ZERO_BI,
 } from "./helpers";
 import {
+	dailyActiveUsersUpdate,
 	dailyVolumeUpdate,
 	hourlyVolumeUpdate,
+	monthlyActiveUsersUpdate,
 	riseTokenUpdate,
 } from "./updates";
 
@@ -64,46 +63,8 @@ export function handleRiseTokenMinted(event: RiseTokenMinted): void {
 	}
 	user.save();
 
-	let dayTimestamp = event.block.timestamp.div(BigInt.fromI32(86400));
-	let dau = DailyActiveUser.load(dayTimestamp.toString());
-	if (dau == null) {
-		dau = new DailyActiveUser(dayTimestamp.toString());
-		dau.uniqueUsersCount = ONE_BI;
-		dau.timestamp = dayTimestamp.times(BigInt.fromI32(86400));
-		dau.users = [user.id];
-		dau.save();
-	} else {
-		if (
-			user.lastTransactionTimestamp.div(BigInt.fromI32(86400)) !=
-			dayTimestamp
-		) {
-			dau.uniqueUsersCount = dau.uniqueUsersCount.plus(ONE_BI);
-			dau.users = dau.users.concat([user.id]);
-			dau.timestamp = dayTimestamp.times(BigInt.fromI32(86400));
-			dau.save();
-		}
-	}
-
-	let monthTimestamp = event.block.timestamp.div(BigInt.fromI32(2592000));
-	let mau = MonthlyActiveUser.load(monthTimestamp.toString());
-	if (mau == null) {
-		mau = new MonthlyActiveUser(monthTimestamp.toString());
-		mau.uniqueUsersCount = ONE_BI;
-		mau.timestamp = monthTimestamp.times(BigInt.fromI32(2592000));
-		mau.users = [user.id];
-		mau.save();
-	} else {
-		if (
-			user.lastTransactionTimestamp.div(BigInt.fromI32(2592000)) !=
-			monthTimestamp
-		) {
-			mau.uniqueUsersCount = mau.uniqueUsersCount.plus(ONE_BI);
-			mau.users = mau.users.concat([user.id]);
-			mau.timestamp = monthTimestamp.times(BigInt.fromI32(2592000));
-			mau.save();
-		}
-	}
-
+	dailyActiveUsersUpdate(event, user);
+	monthlyActiveUsersUpdate(event, user);
 	user.lastTransactionTimestamp = event.block.timestamp;
 	user.save();
 
@@ -156,46 +117,8 @@ export function handleRiseTokenBurned(event: RiseTokenBurned): void {
 	}
 	user.save();
 
-	let dayTimestamp = event.block.timestamp.div(BigInt.fromI32(86400));
-	let dau = DailyActiveUser.load(dayTimestamp.toString());
-	if (dau == null) {
-		dau = new DailyActiveUser(dayTimestamp.toString());
-		dau.uniqueUsersCount = ONE_BI;
-		dau.timestamp = dayTimestamp.times(BigInt.fromI32(86400));
-		dau.users = [user.id];
-		dau.save();
-	} else {
-		if (
-			user.lastTransactionTimestamp.div(BigInt.fromI32(86400)) !=
-			dayTimestamp
-		) {
-			dau.uniqueUsersCount = dau.uniqueUsersCount.plus(ONE_BI);
-			dau.users = dau.users.concat([user.id]);
-			dau.timestamp = dayTimestamp.times(BigInt.fromI32(86400));
-			dau.save();
-		}
-	}
-
-	let monthTimestamp = event.block.timestamp.div(BigInt.fromI32(2592000));
-	let mau = MonthlyActiveUser.load(monthTimestamp.toString());
-	if (mau == null) {
-		mau = new MonthlyActiveUser(monthTimestamp.toString());
-		mau.uniqueUsersCount = ONE_BI;
-		mau.timestamp = monthTimestamp.times(BigInt.fromI32(2592000));
-		mau.users = [user.id];
-		mau.save();
-	} else {
-		if (
-			user.lastTransactionTimestamp.div(BigInt.fromI32(2592000)) !=
-			monthTimestamp
-		) {
-			mau.uniqueUsersCount = mau.uniqueUsersCount.plus(ONE_BI);
-			mau.users = mau.users.concat([user.id]);
-			mau.timestamp = monthTimestamp.times(BigInt.fromI32(2592000));
-			mau.save();
-		}
-	}
-
+	dailyActiveUsersUpdate(event, user);
+	monthlyActiveUsersUpdate(event, user);
 	user.lastTransactionTimestamp = event.block.timestamp;
 	user.save();
 
@@ -307,46 +230,8 @@ export function handleSupplyAdded(event: SupplyAdded): void {
 	}
 	user.save();
 
-	let dayTimestamp = event.block.timestamp.div(BigInt.fromI32(86400));
-	let dau = DailyActiveUser.load(dayTimestamp.toString());
-	if (dau == null) {
-		dau = new DailyActiveUser(dayTimestamp.toString());
-		dau.uniqueUsersCount = ONE_BI;
-		dau.timestamp = dayTimestamp.times(BigInt.fromI32(86400));
-		dau.users = [user.id];
-		dau.save();
-	} else {
-		if (
-			user.lastTransactionTimestamp.div(BigInt.fromI32(86400)) !=
-			dayTimestamp
-		) {
-			dau.uniqueUsersCount = dau.uniqueUsersCount.plus(ONE_BI);
-			dau.users = dau.users.concat([user.id]);
-			dau.timestamp = dayTimestamp.times(BigInt.fromI32(86400));
-			dau.save();
-		}
-	}
-
-	let monthTimestamp = event.block.timestamp.div(BigInt.fromI32(2592000));
-	let mau = MonthlyActiveUser.load(monthTimestamp.toString());
-	if (mau == null) {
-		mau = new MonthlyActiveUser(monthTimestamp.toString());
-		mau.uniqueUsersCount = ONE_BI;
-		mau.timestamp = monthTimestamp.times(BigInt.fromI32(2592000));
-		mau.users = [user.id];
-		mau.save();
-	} else {
-		if (
-			user.lastTransactionTimestamp.div(BigInt.fromI32(2592000)) !=
-			monthTimestamp
-		) {
-			mau.uniqueUsersCount = mau.uniqueUsersCount.plus(ONE_BI);
-			mau.users = mau.users.concat([user.id]);
-			mau.timestamp = monthTimestamp.times(BigInt.fromI32(2592000));
-			mau.save();
-		}
-	}
-
+	dailyActiveUsersUpdate(event, user);
+	monthlyActiveUsersUpdate(event, user);
 	user.lastTransactionTimestamp = event.block.timestamp;
 	user.save();
 
@@ -386,46 +271,8 @@ export function handleSupplyRemoved(event: SupplyRemoved): void {
 	}
 	user.save();
 
-	let dayTimestamp = event.block.timestamp.div(BigInt.fromI32(86400));
-	let dau = DailyActiveUser.load(dayTimestamp.toString());
-	if (dau == null) {
-		dau = new DailyActiveUser(dayTimestamp.toString());
-		dau.uniqueUsersCount = ONE_BI;
-		dau.timestamp = dayTimestamp.times(BigInt.fromI32(86400));
-		dau.users = [user.id];
-		dau.save();
-	} else {
-		if (
-			user.lastTransactionTimestamp.div(BigInt.fromI32(86400)) !=
-			dayTimestamp
-		) {
-			dau.uniqueUsersCount = dau.uniqueUsersCount.plus(ONE_BI);
-			dau.users = dau.users.concat([user.id]);
-			dau.timestamp = dayTimestamp.times(BigInt.fromI32(86400));
-			dau.save();
-		}
-	}
-
-	let monthTimestamp = event.block.timestamp.div(BigInt.fromI32(2592000));
-	let mau = MonthlyActiveUser.load(monthTimestamp.toString());
-	if (mau == null) {
-		mau = new MonthlyActiveUser(monthTimestamp.toString());
-		mau.uniqueUsersCount = ONE_BI;
-		mau.timestamp = monthTimestamp.times(BigInt.fromI32(2592000));
-		mau.users = [user.id];
-		mau.save();
-	} else {
-		if (
-			user.lastTransactionTimestamp.div(BigInt.fromI32(2592000)) !=
-			monthTimestamp
-		) {
-			mau.uniqueUsersCount = mau.uniqueUsersCount.plus(ONE_BI);
-			mau.users = mau.users.concat([user.id]);
-			mau.timestamp = monthTimestamp.times(BigInt.fromI32(2592000));
-			mau.save();
-		}
-	}
-
+	dailyActiveUsersUpdate(event, user);
+	monthlyActiveUsersUpdate(event, user);
 	user.lastTransactionTimestamp = event.block.timestamp;
 	user.save();
 

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -108,3 +108,26 @@ export const oracleAddress = Address.fromString(
 export const vaultContract = RiseTokenVault.bind(vaultAddress);
 
 export const oracleContract = Oracle.bind(oracleAddress);
+
+export function getDailyId(timestamp: BigInt): string {
+	const date = new Date(timestamp.toI64() * 1000);
+	const array = date.toISOString().split("-");
+	const id = array[0]
+		.concat("-")
+		.concat(array[1])
+		.concat(array[2]);
+	return id;
+}
+
+export function getMonthlyId(timestamp: BigInt): string {
+	const date = new Date(timestamp.toI64() * 1000);
+	const array = date.toISOString().split("-");
+	const id = array[0].concat("-").concat(array[1]);
+	return id;
+}
+
+export function getTimestampFromId(id: string): BigInt {
+	const date = Date.parse(id);
+	const timestamp: BigInt = BigInt.fromI64(date.getTime() / 1000);
+	return timestamp;
+}

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -109,19 +109,28 @@ export const vaultContract = RiseTokenVault.bind(vaultAddress);
 
 export const oracleContract = Oracle.bind(oracleAddress);
 
+// Date ISO String example --> 2022-01-28T18:22:31.000Z
+
 export function getDailyId(timestamp: BigInt): string {
 	const date = new Date(timestamp.toI64() * 1000);
-	const array = date.toISOString().split("-");
+	const array = date
+		.toISOString()
+		.split("T")[0]
+		.split("-");
 	const id = array[0]
 		.concat("-")
 		.concat(array[1])
+		.concat("-")
 		.concat(array[2]);
 	return id;
 }
 
 export function getMonthlyId(timestamp: BigInt): string {
 	const date = new Date(timestamp.toI64() * 1000);
-	const array = date.toISOString().split("-");
+	const array = date
+		.toISOString()
+		.split("T")[0]
+		.split("-");
 	const id = array[0].concat("-").concat(array[1]);
 	return id;
 }


### PR DESCRIPTION
The monthly active users only insert data until June. Apparently, some timestamps in July are included in the June category, which is wrong.

For example, if the timestamp is1657722674 which is Wednesday, July 13, 2022 9:31:14 PM GMT+07:00 and then we divide it by 2592000 , rounded it down, and then multiplied it by 2592000 again, we got 1656288000 which is Monday, June 27, 2022 7:00:00 AM GMT+07:00

The current method for getting the month in timestamp is by dividing timestamp with 2592000. The 2592000 is calculated based on 86400 * 30 

we need to get the correct month of the timestamp.